### PR TITLE
Case insensetive type

### DIFF
--- a/node/bin/cli.js
+++ b/node/bin/cli.js
@@ -11,24 +11,24 @@ const propertiesCommand = require('../src/commands/properties');
 const { logger } = require('../src/helpers/logger');
 
 yargs
-    .usage('Sample app that interacts with Hubspot CRM objects')
-    .exitProcess(false)
-    .fail((msg, err, yargs) => {
-        if (msg === null) {
-            yargs.showHelp();
-            process.exit(0);
-        } else {
-            logger.error(msg);
-            process.exit(1);
-        }
-    })
-    .command(authCommand)
-    .command(getCommand)
-    .command(createCommand)
-    .command(updateCommand)
-    .command(deleteCommand)
-    .command(propertiesCommand)
-    .help()
-    .recommendCommands()
-    .demandCommand(1, '')
-    .strictCommands().argv;
+  .usage('Sample app that interacts with Hubspot CRM objects')
+  .exitProcess(false)
+  .fail((msg, err, yargs) => {
+    if (msg === null) {
+      yargs.showHelp();
+      process.exit(0);
+    } else {
+      logger.error(msg);
+      process.exit(1);
+    }
+  })
+  .command(authCommand)
+  .command(getCommand)
+  .command(createCommand)
+  .command(updateCommand)
+  .command(deleteCommand)
+  .command(propertiesCommand)
+  .help()
+  .recommendCommands()
+  .demandCommand(1, '')
+  .strictCommands().argv;

--- a/node/src/commands/create.js
+++ b/node/src/commands/create.js
@@ -12,7 +12,6 @@ exports.describe = 'Create CRM object';
 exports.handler = async (options) => {
   const { objectType, ...properties } = options;
 
-  console.log(`Object Type, ${objectType}`);
   if (!checkConfig()) {
     process.exit(1);
   }

--- a/node/src/commands/create.js
+++ b/node/src/commands/create.js
@@ -27,7 +27,7 @@ exports.builder = (yargs) => {
     describe: 'CRM object type',
     type: 'string',
     choices: Object.keys(AVAILABLE_OBJECT_TYPES),
-    coerce: arg => arg.toLowerCase(),
+    coerce: (arg) => arg.toLowerCase(),
   });
   return yargs;
 };

--- a/node/src/commands/create.js
+++ b/node/src/commands/create.js
@@ -12,6 +12,7 @@ exports.describe = 'Create CRM object';
 exports.handler = async (options) => {
   const { objectType, ...properties } = options;
 
+  console.log(`Object Type, ${objectType}`);
   if (!checkConfig()) {
     process.exit(1);
   }
@@ -27,6 +28,7 @@ exports.builder = (yargs) => {
     describe: 'CRM object type',
     type: 'string',
     choices: Object.keys(AVAILABLE_OBJECT_TYPES),
+    coerce: arg => arg.toLowerCase(),
   });
   return yargs;
 };

--- a/node/src/commands/delete.js
+++ b/node/src/commands/delete.js
@@ -26,7 +26,7 @@ exports.builder = (yargs) => {
     describe: 'CRM object type',
     type: 'string',
     choices: Object.keys(AVAILABLE_OBJECT_TYPES),
-    coerce: arg => arg.toLowerCase(),
+    coerce: (arg) => arg.toLowerCase(),
   });
 
   yargs.positional('objectId', {

--- a/node/src/commands/delete.js
+++ b/node/src/commands/delete.js
@@ -26,6 +26,7 @@ exports.builder = (yargs) => {
     describe: 'CRM object type',
     type: 'string',
     choices: Object.keys(AVAILABLE_OBJECT_TYPES),
+    coerce: arg => arg.toLowerCase(),
   });
 
   yargs.positional('objectId', {

--- a/node/src/commands/get.js
+++ b/node/src/commands/get.js
@@ -41,7 +41,7 @@ exports.builder = (yargs) => {
       ...Object.values(AVAILABLE_OBJECT_TYPES),
       ...Object.keys(AVAILABLE_OBJECT_TYPES),
     ].sort(),
-    coerce: arg => arg.toLowerCase(),
+    coerce: (arg) => arg.toLowerCase(),
   });
 
   yargs.positional('objectId', {

--- a/node/src/commands/get.js
+++ b/node/src/commands/get.js
@@ -41,6 +41,7 @@ exports.builder = (yargs) => {
       ...Object.values(AVAILABLE_OBJECT_TYPES),
       ...Object.keys(AVAILABLE_OBJECT_TYPES),
     ].sort(),
+    coerce: arg => arg.toLowerCase(),
   });
 
   yargs.positional('objectId', {
@@ -49,6 +50,7 @@ exports.builder = (yargs) => {
   });
 
   yargs.option('query', {
+    alias: 'q',
     describe: 'searching filter for getting list of objects',
     type: 'string',
   });

--- a/node/src/commands/properties.js
+++ b/node/src/commands/properties.js
@@ -23,6 +23,7 @@ exports.builder = (yargs) => {
     describe: 'CRM object type',
     type: 'string',
     choices: Object.values(AVAILABLE_OBJECT_TYPES),
+    coerce: arg => arg.toLowerCase(),
   });
   return yargs;
 };

--- a/node/src/commands/properties.js
+++ b/node/src/commands/properties.js
@@ -23,7 +23,7 @@ exports.builder = (yargs) => {
     describe: 'CRM object type',
     type: 'string',
     choices: Object.values(AVAILABLE_OBJECT_TYPES),
-    coerce: arg => arg.toLowerCase(),
+    coerce: (arg) => arg.toLowerCase(),
   });
   return yargs;
 };

--- a/node/src/commands/update.js
+++ b/node/src/commands/update.js
@@ -28,6 +28,7 @@ exports.builder = (yargs) => {
     describe: 'CRM object type',
     type: 'string',
     choices: Object.keys(AVAILABLE_OBJECT_TYPES),
+    coerce: arg => arg.toLowerCase(),
   });
 
   yargs.positional('objectId', {

--- a/node/src/commands/update.js
+++ b/node/src/commands/update.js
@@ -28,7 +28,7 @@ exports.builder = (yargs) => {
     describe: 'CRM object type',
     type: 'string',
     choices: Object.keys(AVAILABLE_OBJECT_TYPES),
-    coerce: arg => arg.toLowerCase(),
+    coerce: (arg) => arg.toLowerCase(),
   });
 
   yargs.positional('objectId', {


### PR DESCRIPTION
Making object type arg case insensitive in commands. Also added 'q' alias for 'query' option to `get` command